### PR TITLE
Respect multiple backslashes in cf3String skip pattern

### DIFF
--- a/syntax/cf3.vim
+++ b/syntax/cf3.vim
@@ -69,7 +69,7 @@ syn match   cf3Esc          /\\\\[sSdD+][\+\*]*/ contained
 syn region  cf3Array        start=/\(\\\)\@<!\[/ end=/\]/ contained contains=cf3Var
 " Variables wrapped in {} or ()
 syn region  cf3Var          start=/[$@][{(]/ end=/[})]/ contains=cf3Var,cf3Array
-syn region  cf3String       start=/\z\("\|'\)/ skip=/\\\z1/ end=/\z1/ contains=cf3Var,cf3Esc,cf3Array
+syn region  cf3String       start=/\z\("\|'\)/ skip=/\(\\\)\@<!\(\\\\\)*\\\z1/ end=/\z1/ contains=cf3Var,cf3Esc,cf3Array
 syn region  cf3Fold 	    start="{" end="}" transparent fold
 
 syn keyword cf3Type			string int real slist ilist rlist data


### PR DESCRIPTION
Quote marks should be escaped only if they are preceded by an odd number of consecutive backslashes.  This fixes the highlighting of strings such as ```"\\"```.