### PR TITLE
make snippets work wherever it might be

### DIFF
--- a/ftplugin/cf3.vim
+++ b/ftplugin/cf3.vim
@@ -21,6 +21,8 @@ if exists("b:loaded_CFE3Ftplugin")
 endif
 let b:loaded_CFE3Ftplugin = 1
 
+let s:install_dir = expand('<sfile>:p:h:h')
+
 " =============== Keyword Abbreviations  ===============
 " enable keyword abbreviations with by adding 
 " "let g:EnableCFE3KeywordAbbreviations=1" to your vimrc
@@ -169,13 +171,13 @@ nnoremap <buffer> <silent>  <ESC>=  :call CF3AlignAssignments("vars")<CR>
 
 " For pasting code snippets
 function! Pastefile( FILE )
-        let arg_file = $HOME."/.vim/snippets/".a:FILE
+        let arg_file = s:install_dir."/snippets/".a:FILE
         let @" = join( readfile( arg_file ), "\n" )
         put 
         return ""
 endfunction
 
-nnoremap <buffer> ,k :read $HOME/.vim/snippets/template.cf<CR>kdd
+nnoremap <buffer> ,k :call Pastefile("template.cf")<CR>kdd
 
 " TODO
 " Indents


### PR DESCRIPTION
I almost forgot about this patch, or why I had done it. 

I use 'pathogen' to inject this into vim, so location of snippets is not directly under $HOME/.vim

So, this makes snippets work, for me....though I haven't had a use for it.

If only there were a way to auto-magically generate action/classes lines for delta reporting ... :smiling_imp: 

_And, then I almost lost everything in try to re-sync/merge upstream, etc. :blush:  Yet, I keep thinking that someday I'm going to convert my masterfiles from subversion to git.  Probably shouldn't be editing two different policy files in different screens, and then starting on a third.... I've had to reverse merge/commit the same policy file 3 times today_