### PR TITLE
Differentiate std library and built-in functions

### DIFF
--- a/syntax/cf3.vim
+++ b/syntax/cf3.vim
@@ -352,6 +352,7 @@ if version >= 508 || !exists("did_cfg_syn_inits")
 	hi cf3Type ctermfg=Magenta 
 	hi Identifier ctermfg=Blue 
 	hi Function ctermfg=DarkGreen
+	hi Library ctermfg=DarkGrey
 	hi cf3ClassBlock ctermfg=Yellow
 
     HiLink cf3Bundle        Statement
@@ -373,7 +374,7 @@ if version >= 508 || !exists("did_cfg_syn_inits")
 	HiLink cf3String        String
 	HiLink cf3BuiltIns		Function
    HiLink cf3Evolve_freelib Function
-	HiLink cf3Stdlib		Function
+	HiLink cf3Stdlib		Library
 
     HiLink cf3Identifier    cf3Arrows
     HiLink cf3Esc           Special


### PR DESCRIPTION
Fix stdlib features and built-ins so they are no longer the same color.  I've found that using the same color for both confuses students learning CFEngine policy writing.  Standard library features require the standard library to be loaded in your policy; built-in functions do not.