### PR TITLE
Regenerate the cf3BuiltIns keywords

### DIFF
--- a/syntax/cf3.vim
+++ b/syntax/cf3.vim
@@ -75,36 +75,38 @@ syn region  cf3Fold 	    start="{" end="}" transparent fold
 syn keyword cf3Type			string int real slist ilist rlist data
 
 " The following list may be automatically generated using
-" tools/extract_cf3BuiltIns.sh 
+" tools/extract_cf3BuiltIns.sh
 
-" Last update: 2015/10/04 - git tag e0392e5c7f0087fa3b0df36ca3b83f4136924ba9
+" Last update: 2016/11/28 - git tag 571987454f0d3814b4f7ed141759d4a7c3d2c635
 
 syn keyword cf3BuiltIns	accessedbefore accumulated ago and bundlesmatching contained
-syn keyword cf3BuiltIns	bundlestate canonify canonifyuniquely changedbefore classesmatching classify contained
-syn keyword cf3BuiltIns	classmatch concat countclassesmatching countlinesmatching data_expand data_readstringarray contained
-syn keyword cf3BuiltIns	data_readstringarrayidx data_regextract datastate difference dirname diskfree contained
-syn keyword cf3BuiltIns	escape eval every execresult expandrange file_hash contained
-syn keyword cf3BuiltIns	fileexists filesexist filesize filestat filter findfiles contained
-syn keyword cf3BuiltIns	format getclassmetatags getenv getfields getgid getindices contained
-syn keyword cf3BuiltIns	getuid getusers getvalues getvariablemetatags grep groupexists contained
-syn keyword cf3BuiltIns	hash hashmatch host2ip hostinnetgroup hostrange hostsseen contained
-syn keyword cf3BuiltIns	hostswithclass hubknowledge ifelse intersection ip2host iprange contained
-syn keyword cf3BuiltIns	irange isdir isexecutable isgreaterthan islessthan islink contained
-syn keyword cf3BuiltIns	isnewerthan isplain isvariable join lastnode laterthan contained
-syn keyword cf3BuiltIns	ldaparray ldaplist ldapvalue length lsdir makerule contained
-syn keyword cf3BuiltIns	maparray mapdata maplist max mean mergedata contained
-syn keyword cf3BuiltIns	min none not now nth on contained
+syn keyword cf3BuiltIns	bundlestate callstack_callers callstack_promisers canonify canonifyuniquely changedbefore contained
+syn keyword cf3BuiltIns	classesmatching classify classmatch concat countclassesmatching countlinesmatching contained
+syn keyword cf3BuiltIns	data_expand data_readstringarray data_readstringarrayidx data_regextract datastate difference contained
+syn keyword cf3BuiltIns	dirname diskfree escape eval every execresult contained
+syn keyword cf3BuiltIns	expandrange file_hash fileexists filesexist filesize filestat contained
+syn keyword cf3BuiltIns	filter findfiles findprocesses format getclassmetatags getenv contained
+syn keyword cf3BuiltIns	getfields getgid getindices getuid getuserinfo getusers contained
+syn keyword cf3BuiltIns	getvalues getvariablemetatags grep groupexists hash hashmatch contained
+syn keyword cf3BuiltIns	host2ip hostinnetgroup hostrange hostsseen hostswithclass hubknowledge contained
+syn keyword cf3BuiltIns	ifelse intersection ip2host iprange irange isdir contained
+syn keyword cf3BuiltIns	isexecutable isgreaterthan isipinsubnet islessthan islink isnewerthan contained
+syn keyword cf3BuiltIns	isplain isvariable join lastnode laterthan ldaparray contained
+syn keyword cf3BuiltIns	ldaplist ldapvalue length lsdir makerule maparray contained
+syn keyword cf3BuiltIns	mapdata maplist max mean mergedata min contained
+syn keyword cf3BuiltIns	network_connections none not now nth on contained
 syn keyword cf3BuiltIns	or packagesmatching packageupdatesmatching parseintarray parsejson parserealarray contained
 syn keyword cf3BuiltIns	parsestringarray parsestringarrayidx parseyaml peerleader peerleaders peers contained
-syn keyword cf3BuiltIns	product randomint readcsv readdata readfile readintarray contained
-syn keyword cf3BuiltIns	readintlist readjson readrealarray readreallist readstringarray readstringarrayidx contained
-syn keyword cf3BuiltIns	readstringlist readtcp readyaml regarray regcmp regextract contained
-syn keyword cf3BuiltIns	registryvalue regldap regline reglist remoteclassesmatching remotescalar contained
-syn keyword cf3BuiltIns	returnszero reverse rrange selectservers shuffle some contained
-syn keyword cf3BuiltIns	sort splayclass splitstring storejson strcmp strftime contained
-syn keyword cf3BuiltIns	string_downcase string_head string_length string_mustache string_reverse string_split contained
-syn keyword cf3BuiltIns	string_tail string_upcase sublist sum translatepath unique contained
-syn keyword cf3BuiltIns	usemodule userexists variablesmatching contained
+syn keyword cf3BuiltIns	processexists product randomint readcsv readdata readfile contained
+syn keyword cf3BuiltIns	readintarray readintlist readjson readrealarray readreallist readstringarray contained
+syn keyword cf3BuiltIns	readstringarrayidx readstringlist readtcp readyaml regarray regcmp contained
+syn keyword cf3BuiltIns	regex_replace regextract registryvalue regldap regline reglist contained
+syn keyword cf3BuiltIns	remoteclassesmatching remotescalar returnszero reverse rrange selectservers contained
+syn keyword cf3BuiltIns	shuffle some sort splayclass splitstring storejson contained
+syn keyword cf3BuiltIns	strcmp strftime string_downcase string_head string_length string_mustache contained
+syn keyword cf3BuiltIns	string_reverse string_split string_tail string_upcase sublist sum contained
+syn keyword cf3BuiltIns	translatepath unique url_get usemodule userexists variablesmatching contained
+syn keyword cf3BuiltIns	variablesmatching_as_data contained
 
 " The following list may be automatically generated using
 " tools/extract_cf3evolve_freelib.sh


### PR DESCRIPTION
This will pick up the new functions such as url_get() which have been introduced in Cfengine 3.9