### PR TITLE
Changed slist abbreviation to fix problem with SpaceVim loading ftplugin

### DIFF
--- a/ftplugin/cf3.vim
+++ b/ftplugin/cf3.vim
@@ -45,7 +45,7 @@ function! EnableCFE3KeywordAbbreviations()
     iab <buffer> met methods:
     iab <buffer> pro processes:
     iab <buffer> rep reports:
-    iab <buffer> sli slist => {
+    iab <buffer> sli slist => { }<Left><Left>
     iab <buffer> str string => "<C-R>=Eatchar('\s')<CR>
     iab <buffer> sysw ${sys.workdir}
     iab <buffer> ub usebundle =>
@@ -186,6 +186,9 @@ nnoremap <buffer> ,s :call Pastefile("stdlib.cf")<CR>kdd
 " Other Cfengine information: http://watson-wilson.ca/cfengine/
 "
 " CHANGES
+" Friday April 22 2022
+" - Added closing curly brace '}' to slist IAB in order to prevent errors when plugin is loaded by SpaceVim
+"
 " Wednesday January 09 2013 
 " Operator alignment now works for just '=>' with ',=' or 'string, stlist ,etc
 " and => ' with '<ESC>='


### PR DESCRIPTION
I tried adding `vim_cf3` as a `custom_plugin` in
SpaceVim (https://github.com/SpaceVim/SpaceVim) by adding the following to
`~/.SpaceVim.d/init.toml`

```
[[custom_plugins]]
repo = "https://github.com/neilhwatson/vim_cf3"
merged = false
```

When I run vim I get an error:

```
Error detected while processing BufNewFile Autocommands for "*.cf"..FileType Autocommands for "*"..function <SNR>101_LoadFTPlugin[17]..script /home/vagrant/.cache/vimfiles/repos/github.com/neilhwatson/vim_cf3/ftplugin/cf3.vim:
line   53:
E1151: Mismatched endfunction
line   32:
E1171: Missing } after inline function
```

This change resolved the issue for me and abbreviation for sli works after it's
toggled on.